### PR TITLE
[GP-9150] Add host IP as env variable for DataDog

### DIFF
--- a/charts/gitprime-app/v2.0.0/templates/dataPipeline/_deployment.tpl
+++ b/charts/gitprime-app/v2.0.0/templates/dataPipeline/_deployment.tpl
@@ -47,6 +47,10 @@ spec:
               value: {{ include "helpers.configServerURL" . }}
             - name: GP_LOG_LEVEL
               value: {{ quote .templateData.logLevel | default "INFO" | lower }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           {{- if .templateData.javaOptions }}
             - name: JAVA_OPTS
               value: {{ quote .templateData.javaOptions }}


### PR DESCRIPTION
Adding a new environment variable for the host IP used for DataDog agent.