### PR TITLE
[GP-9912] Default settings for utility pods

### DIFF
--- a/charts/gitprime-app/v3.0.0/templates/dataPipeline/_deployment.tpl
+++ b/charts/gitprime-app/v3.0.0/templates/dataPipeline/_deployment.tpl
@@ -83,9 +83,9 @@ spec:
             - name: GP_AOD_LISTENERS
               value: {{ quote .templateData.aodListeners }}
           {{- end}}
-          {{- if .templateData.incrThreadsPerListener }}
+          {{- if .templateData.aodThreadsPerListener }}
             - name: GP_AOD_WORKERS_PER_LISTENER
-              value: {{ quote .templateData.incrThreadsPerListener }}
+              value: {{ quote .templateData.aodThreadsPerListener }}
           {{- end}}
           {{- if .templateData.ticketListeners }}
             - name: GP_TICKET_LISTENERS
@@ -94,6 +94,22 @@ spec:
           {{- if .templateData.ticketThreadsPerListener }}
             - name: GP_TICKET_WORKERS_PER_LISTENERS
               value: {{ quote .templateData.ticketThreadsPerListener }}
+          {{- end}}
+          {{- if .templateData.prListeners }}
+            - name: GP_PR_LISTENERS
+              value: {{ quote .templateData.prListeners }}
+          {{- end}}
+          {{- if .templateData.prThreadsPerListener }}
+            - name: GP_PR_WORKERS_PER_LISTENER
+              value: {{ quote .templateData.prThreadsPerListener }}
+          {{- end}}
+          {{- if .templateData.ticketWebhookListeners }}
+            - name: GP_TICKET_WEBHOOK_LISTENERS
+              value: {{ quote .templateData.ticketWebhookListeners }}
+          {{- end}}
+          {{- if .templateData.ticketWebhookThreadsPerListener }}
+            - name: GP_TICKET_WEBHOOK_WORKERS_PER_LISTENER
+              value: {{ quote .templateData.ticketWebhookThreadsPerListener }}
           {{- end}}
           {{- if .templateData.incrMaxCommitCount }}
             - name: GP_INCREMENTAL_COMMIT_COUNT

--- a/charts/gitprime-app/v3.0.0/templates/dataPipeline/utility-deployment.yaml
+++ b/charts/gitprime-app/v3.0.0/templates/dataPipeline/utility-deployment.yaml
@@ -2,6 +2,18 @@
 {{- $_ := set $templateData "operationMode" "utility" }}
 {{- $_ := set $templateData "replicaCount" 1 }}
 {{- $_ := set $templateData "logLevel" "DEBUG" }}
+{{- $_ := set $templateData "aodListeners" 0 }}
+{{- $_ := set $templateData "aodThreadsPerListener" 0 }}
+{{- $_ := set $templateData "incrListeners" 0 }}
+{{- $_ := set $templateData "incrThreadsPerListener" 0 }}
+{{- $_ := set $templateData "newListeners" 0 }}
+{{- $_ := set $templateData "newThreadsPerListener" 0 }}
+{{- $_ := set $templateData "prListeners" 0 }}
+{{- $_ := set $templateData "prThreadsPerListener" 0 }}
+{{- $_ := set $templateData "ticketListeners" 0 }}
+{{- $_ := set $templateData "ticketThreadsPerListener" 0 }}
+{{- $_ := set $templateData "ticketWebhookListeners" 0 }}
+{{- $_ := set $templateData "ticketWebhookThreadsPerListener" 0 }}
 {{- $templateData := dict "Values" .Values "templateData" $templateData }}
 {{- include "dataPipeline.deploymentTemplate" $templateData }}
 


### PR DESCRIPTION
- Updating the default settings for utility pods to turn off all queue listeners
- Fix a bug where the AOD_WORKERS_PER_LISTENER env variable was looking at the wrong template value
- Added ticket webhook and PR env variables that were missing from the deployment template