### PR TITLE
GP-10484: Removing colliding env variables

### DIFF
--- a/charts/gitprime-app/v3.0.5/values.yaml
+++ b/charts/gitprime-app/v3.0.5/values.yaml
@@ -34,8 +34,6 @@ dataPipeline:
         value: 0
       - name: GP_AOD_LISTENERS
         value: 0
-      - name: GP_NEW_LISTENERS
-        value: 1
       - name: GP_INCREMENTAL_LISTENERS
         value: 0
       - name: GP_TICKET_LISTENERS
@@ -72,8 +70,6 @@ dataPipeline:
         value: 0
       - name: GP_NEW_LISTENERS
         value: 0
-      - name: GP_INCREMENTAL_LISTENERS
-        value: 1
       - name: GP_TICKET_LISTENERS
         value: 0
       - name: GP_TICKET_WEBHOOK_LISTENERS
@@ -104,8 +100,6 @@ dataPipeline:
     environment:
       - name: GP_REPO_DELETE_LISTENERS
         value: 0
-      - name: GP_AOD_LISTENERS
-        value: 1
       - name: GP_NEW_LISTENERS
         value: 0
       - name: GP_INCREMENTAL_LISTENERS
@@ -145,10 +139,6 @@ dataPipeline:
         value: 0
       - name: GP_INCREMENTAL_LISTENERS
         value: 0
-      - name: GP_TICKET_LISTENERS
-        value: 1
-      - name: GP_TICKET_WORKERS_PER_LISTENER
-        value: 1
       - name: GP_TICKET_WEBHOOK_LISTENERS
         value: 1
       - name: GP_TICKET_WEBHOOK_WORKERS_PER_LISTENER
@@ -188,10 +178,6 @@ dataPipeline:
         value: 0
       - name: GP_TICKET_WEBHOOK_LISTENERS
         value: 0
-      - name: GP_PR_LISTENERS
-        value: 1
-      - name: GP_PR_WORKERS_PER_LISTENER
-        value: 1
       - name: GP_PR_WEBHOOK_LISTENERS
         value: 1
       - name: GP_PR_WEBHOOK_WORKERS_PER_LISTENER


### PR DESCRIPTION
Turns out, Rancher does not deal with overriding the default env variables!