### PR TITLE
INFRA-915: Fix command should be called job_command in helmrelease values

### DIFF
--- a/releases/sandbox/gp-pyspark/gp-pyspark.yaml
+++ b/releases/sandbox/gp-pyspark/gp-pyspark.yaml
@@ -15,7 +15,6 @@ spec:
     ref: master
   values:
     jobs:
-      # Override jobs[0] in values.yaml
       - name: gp-pyspark-nightly
         image:
           repository: gp-docker.gitprime-ops.com/cloud/gp-pyspark
@@ -28,8 +27,16 @@ spec:
           value: "-d64 -Xms2g -Xmx8g"
         - name: DATADOG_ENABLED
           value: "yes"
+        - name: SYSTEM_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         schedule: "0 8 * * 1-6"
-        command: "python driver.py '2019-12-01' $(date \"+%Y-%m-%d\")"
+        job_command: "python driver.py '2019-12-01' $(date \"+%Y-%m-%d\")"
         resources:
           limits:
             cpu: 12
@@ -54,8 +61,16 @@ spec:
           value: "-d64 -Xms2g -Xmx8g"
         - name: DATADOG_ENABLED
           value: "yes"
+        - name: SYSTEM_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: DD_AGENT_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         schedule: "0 8 * * 0"
-        command: "python driver.py '2019-01-01' $(date \"+%Y-%m-%d\")"
+        job_command: "python driver.py '2019-01-01' $(date \"+%Y-%m-%d\")"
         resources:
           limits:
             cpu: 12 

--- a/releases/test/gp-pyspark/gp-pyspark.yaml
+++ b/releases/test/gp-pyspark/gp-pyspark.yaml
@@ -37,7 +37,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         schedule: "0 8 * * 1-6"
-        command: "python driver.py '2019-12-01' $(date \"+%Y-%m-%d\")"
+        job_command: "python driver.py '2019-12-01' $(date \"+%Y-%m-%d\")"
         resources:
           limits:
             cpu: 6
@@ -71,7 +71,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         schedule: "0 8 * * 0"
-        command: "python driver.py '2019-01-01' $(date \"+%Y-%m-%d\")"
+        job_command: "python driver.py '2019-01-01' $(date \"+%Y-%m-%d\")"
         resources:
           limits:
             cpu: 6


### PR DESCRIPTION
Somehow job_command reverted back to command, which overrides the entrypoint for the container and causes it to not be able to run. `job_command` maps to container args in the helm template.