### PR TITLE
OCTO-434: Create Helm chart for kafka-health service

### DIFF
--- a/charts/gp-reporting-kafka-health/v0.0.1/.helmignore
+++ b/charts/gp-reporting-kafka-health/v0.0.1/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gp-reporting-kafka-health/v0.0.1/Chart.yaml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+appVersion: "0.0.2"
+description: A Helm chart for the GitPrime Reporting Kafka Health Service
+name: gp-reporting-kafka-health
+version: 0.0.1
+icon: https://s3-us-west-2.amazonaws.com/gitprime-email-images/gitprime-logo-icon.png

--- a/charts/gp-reporting-kafka-health/v0.0.1/app-readme.md
+++ b/charts/gp-reporting-kafka-health/v0.0.1/app-readme.md
@@ -1,0 +1,3 @@
+# GitPrime Reporting Kafka Health Service
+
+These are the readme contents.

--- a/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
@@ -45,28 +45,6 @@ questions:
     description: The commit SHA of the GitPrime Application build you want to deploy.
     default: latest
 
-  - variable: volumes.enableLocalMount
-    type: boolean
-    required: true
-    group: "Application"
-    label: "Use Local Mount"
-    description: "If enabled, use the node's local storage directory for repository storage"
-    default: false
-    show_subquestion_if: "true"
-    subquestions:
-      - variable: volumes.nodeMountDirectory
-        type: string
-        label: "Directory on Node"
-        description: "The directory on the node to use for repository storage"
-        required: true
-        default: "/mnt/repo-storage"
-      - variable: volumes.podMountDirectory
-        type: string
-        label: "Directory on Pod"
-        description: "The directory inside the pod to mount the volume."
-        required: true
-        default: "/var/data"
-
   - variable: datadog.enabled
     type: boolean
     required: true

--- a/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
@@ -115,7 +115,7 @@ questions:
     group: "Application / Reporting Kafka Health Service"
     label: Reporting Kafka Health Service CPU Limit
     description: The maximum number of CPUs the services can use.
-    default: "4"
+    default: "1"
 
   - variable: application.resources.limits.memory
     type: string

--- a/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
@@ -99,7 +99,7 @@ questions:
     group: "Application / Reporting Kafka Health Service"
     label: Reporting Kafka Health Service Requested CPU
     description: The number of CPUs the services will request.
-    default: "2"
+    default: "100m"
 
   - variable: application.resources.requests.memory
     type: string

--- a/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
@@ -75,7 +75,7 @@ questions:
     group: "Application / Reporting Kafka Health Service"
     label: Application node port
     description: The port that is exposed on the node which routes to the app port binding
-    default: "30680"
+    default: "30780"
 
   - variable: application.replicaCount
     type: string

--- a/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/questions.yml
@@ -1,0 +1,162 @@
+questions:
+  # General environment settings
+  - variable: environment.parentName
+    type: enum
+    required: true
+    group: "Environment"
+    label: Environment Parent
+    description: The name of the parent environment we will deploy into and funcation as.
+    options:
+      - sandbox
+      - canary
+      - production
+    default: sandbox
+
+  - variable: environment.modifierValue
+    type: enum
+    required: false
+    group: "Environment"
+    label: Environment Modifier
+    description: The modifier name for the environment we will deploy into and funcation as.
+    options:
+      - prime
+      - qa
+      - testing
+      - 01
+      - 02
+      - 03
+      - 04
+      - 05
+      - 06
+      - 07
+      - 08
+      - 09
+      - 10
+    default: "01"
+
+  ####
+  #### Reporting Kafka Health Service Settings
+  ####
+  - variable: build.commitSHA
+    type: string
+    required: true
+    group: "Application"
+    label: Application Build SHA
+    description: The commit SHA of the GitPrime Application build you want to deploy.
+    default: latest
+
+  - variable: volumes.enableLocalMount
+    type: boolean
+    required: true
+    group: "Application"
+    label: "Use Local Mount"
+    description: "If enabled, use the node's local storage directory for repository storage"
+    default: false
+    show_subquestion_if: "true"
+    subquestions:
+      - variable: volumes.nodeMountDirectory
+        type: string
+        label: "Directory on Node"
+        description: "The directory on the node to use for repository storage"
+        required: true
+        default: "/mnt/repo-storage"
+      - variable: volumes.podMountDirectory
+        type: string
+        label: "Directory on Pod"
+        description: "The directory inside the pod to mount the volume."
+        required: true
+        default: "/var/data"
+
+  - variable: datadog.enabled
+    type: boolean
+    required: true
+    group: "Application"
+    label: "Enable DataDog"
+    description: "Turn DataDog APM on for the pipeline"
+
+  - variable: dns.ndots
+    type: string
+    required: false
+    group: "Application"
+    label: "Number of ndots for DNS configuration"
+    description: "Modifies the number of ndots in /etc/resolv.conf"
+    default: 2
+
+  # Reporting Kafka Health Service Settings
+  - variable: application.webPort
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Application port binding
+    description: The port binding that the application uses to listen to web requests
+    default: "8080"
+
+  - variable: application.nodePort
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Application node port
+    description: The port that is exposed on the node which routes to the app port binding
+    default: "30680"
+
+  - variable: application.replicaCount
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Number of Pods for services
+    description: The number of pods to deploy for the services that handle new repositories.
+    default: 1
+
+  - variable: application.javaOptions
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Reporting Kafka Health Service Java Options
+    description: The Java options for the services.
+    default: "-d64 -Xms2g -Xmx4g"
+
+  - variable: application.resources.requests.cpu
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Reporting Kafka Health Service Requested CPU
+    description: The number of CPUs the services will request.
+    default: "2"
+
+  - variable: application.resources.requests.memory
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Reporting Kafka Health Service Requested Memory
+    description: The maximum amount of memory a worker will request.
+    default: "4Gi"
+
+  - variable: application.resources.limits.cpu
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Reporting Kafka Health Service CPU Limit
+    description: The maximum number of CPUs the services can use.
+    default: "4"
+
+  - variable: application.resources.limits.memory
+    type: string
+    required: true
+    group: "Application / Reporting Kafka Health Service"
+    label: Reporting Kafka Health Service Memory Limit
+    description: The maximum amount of memory a service can use.
+    default: "8Gi"
+
+  - variable: application.logLevel
+    type: enum
+    required: true
+    group: "Application"
+    label: Log Level
+    description: The level of logging for this deployment.
+    options:
+      - TRACE
+      - DEBUG
+      - INFO
+      - WARN
+      - ERROR
+    default: "INFO"

--- a/charts/gp-reporting-kafka-health/v0.0.1/templates/NOTES.txt
+++ b/charts/gp-reporting-kafka-health/v0.0.1/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}

--- a/charts/gp-reporting-kafka-health/v0.0.1/templates/_helpers.tpl
+++ b/charts/gp-reporting-kafka-health/v0.0.1/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{/* Creates a value that represents the full environment name */}}
+{{- define "helpers.environment.fullName" }}
+{{- if .Values.environment.modifierValue }}
+{{- .Values.environment.parentName }}-{{ .Values.environment.modifierValue }}
+{{- else }}
+{{- .Values.environment.parentName }}
+{{- end }}
+{{- end }}
+
+{{/* Creates a value for the right configuration server URL */}}
+{{- define "helpers.configServerURL" }}
+{{- if eq .Values.environment.parentName "production" }}
+{{- "https://prod-config-server.gitprime-ops.com" }}
+{{- else }}
+{{- "https://config-server.gitprime-ops.com" }}
+{{- end }}
+{{- end }}

--- a/charts/gp-reporting-kafka-health/v0.0.1/templates/application/_deployment.tpl
+++ b/charts/gp-reporting-kafka-health/v0.0.1/templates/application/_deployment.tpl
@@ -1,0 +1,134 @@
+{{- /* This represents a deployment that runs the Reporting Pipeline health service component and moves into different modes based on */}}
+{{- /* environment variables and the like. */}}
+{{- define "application.deploymentTemplate" }}
+{{- $globalEnvironment := .Values.application.environment }}
+{{- $environment := .templateData.environment }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+  labels:
+    app: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+spec:
+  replicas: {{ .templateData.replicaCount }}
+  selector:
+    matchLabels:
+      app: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        app: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+    spec:
+      containers:
+        - name: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+          image: gp-docker.gitprime-ops.com/cloud/gitprime-reporting-kafka-health-service:{{ .Values.build.commitSHA }}
+          imagePullPolicy: IfNotPresent
+        {{- if .templateData.httpHost }}
+          ports:
+          - name: http
+            containerPort: {{ .Values.application.webPort }}
+        {{- end }}
+          env:
+            - name: ACTIVE_PROFILES
+              value: {{ quote .Values.application.activeProfiles}}
+            - name: SYSTEM_ENV_PARENT
+              value: {{ quote .Values.environment.parentName }}
+            - name: SYSTEM_ENV_MODIFIER
+              value: {{ quote .Values.environment.modifierValue }}
+            - name: SYSTEM_ENV
+              value: {{ include "helpers.environment.fullName" . | quote }}
+            - name: DATADOG_ENABLED
+              value: {{ quote .Values.datadog.enabled }}
+            - name: DNS_CONFIG_NDOTS
+              value: {{ quote .Values.dns.ndots }}
+            - name: SYSTEM_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SYSTEM_OPERATION_MODE
+              value: {{ quote .templateData.operationMode }}
+            - name: SYSTEM_CONFIG_SERVER_URL
+              value: {{ include "helpers.configServerURL" . }}
+            - name: GP_LOG_LEVEL
+              value: {{ quote .templateData.logLevel | default "INFO" | lower }}
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          {{- if .templateData.javaOptions }}
+            - name: JAVA_OPTS
+              value: {{ quote .templateData.javaOptions }}
+          {{- end }}
+          {{- range $globalEnvironment }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end }}
+          {{- range $environment }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+          {{- end }}
+          resources:
+          {{- if .templateData.resources }}
+          {{- if or (.templateData.resources.requests.cpu) (.templateData.resources.requests.memory) }}
+            requests:
+            {{- if .templateData.resources.requests.cpu }}
+              cpu: {{ quote .templateData.resources.requests.cpu }}
+            {{- end }}
+            {{- if .templateData.resources.requests.memory }}
+              memory: {{ .templateData.resources.requests.memory }}
+            {{- end }}
+          {{- end }}
+          {{- if or (.templateData.resources.limits.cpu) (.templateData.resources.limits.memory) }}
+            limits:
+            {{- if .templateData.resources.limits.cpu }}
+              cpu: {{ quote .templateData.resources.limits.cpu }}
+            {{- end }}
+            {{- if .templateData.resources.limits.memory }}
+              memory: {{ .templateData.resources.limits.memory }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.volumes.enableLocalMount }}
+          volumeMounts:
+            - mountPath: {{ quote .Values.volumes.podMountDirectory }}
+              name: repository-storage-volume
+          {{- end }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.volumes.enableLocalMount }}
+      volumes:
+      - hostPath:
+          path: {{ quote .Values.volumes.nodeMountDirectory }}
+          type: DirectoryOrCreate
+        name: repository-storage-volume
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}-nodeport
+  labels:
+    app: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+spec:
+  type: NodePort
+  ports:
+    - name: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}-nodeport
+      port: {{ .Values.application.webPort }}
+      nodePort: {{ .Values.application.nodePort }}
+      targetPort: {{ .Values.application.webPort }}
+  selector:
+    app: gitprime-reporting-kafka-health-{{- template "helpers.environment.fullName" .}}-{{ .templateData.operationMode }}
+{{- end }}

--- a/charts/gp-reporting-kafka-health/v0.0.1/templates/application/_deployment.tpl
+++ b/charts/gp-reporting-kafka-health/v0.0.1/templates/application/_deployment.tpl
@@ -92,11 +92,6 @@ spec:
             {{- end }}
           {{- end }}
           {{- end }}
-          {{- if .Values.volumes.enableLocalMount }}
-          volumeMounts:
-            - mountPath: {{ quote .Values.volumes.podMountDirectory }}
-              name: repository-storage-volume
-          {{- end }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
@@ -108,13 +103,6 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-      {{- if .Values.volumes.enableLocalMount }}
-      volumes:
-      - hostPath:
-          path: {{ quote .Values.volumes.nodeMountDirectory }}
-          type: DirectoryOrCreate
-        name: repository-storage-volume
-      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/gp-reporting-kafka-health/v0.0.1/templates/application/application-deployment.yaml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/templates/application/application-deployment.yaml
@@ -1,0 +1,14 @@
+{{- $templateData := dict "operationMode" "reporting" }}
+{{- $_ := set $templateData "replicaCount" .Values.application.replicaCount }}
+{{- $_ := set $templateData "environment" .Values.application.environment }}
+{{- $_ := set $templateData "javaOptions" .Values.application.javaOptions }}
+{{- $_ := set $templateData "processorThreadCount" .Values.application.processorThreadCount }}
+{{- $_ := set $templateData "maxConcurrentJobs" .Values.application.maxConcurrentJobs }}
+{{- $_ := set $templateData "maxCommitCount" .Values.application.maxCommitCount }}
+{{- $_ := set $templateData "resources" .Values.application.resources }}
+{{- $_ := set $templateData "logLevel" .Values.application.logLevel }}
+{{- $_ := set $templateData "httpHost" "True" }}
+{{- $templateData := dict "Values" .Values "templateData" $templateData }}
+{{- include "application.deploymentTemplate" $templateData }}
+
+

--- a/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
@@ -12,11 +12,6 @@ datadog:
 dns:
   ndots: 2
 
-volumes:
-  enableLocalMount: false
-  nodeMountDirectory: /mnt/working-storage
-  podMountDirectory: /var/working-storage
-
 application:
   replicaCount: 1
   javaOptions: ""

--- a/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
@@ -16,4 +16,4 @@ application:
   replicaCount: 1
   javaOptions: ""
   webPort: "8080"
-  nodePort: "30680"
+  nodePort: "30780"

--- a/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
+++ b/charts/gp-reporting-kafka-health/v0.0.1/values.yaml
@@ -1,0 +1,24 @@
+# We'll start with values for the environment we'll be living in
+environment:
+  parentName: sandbox
+  modifierValue: ""
+
+build:
+  commitSHA: "latest"
+
+datadog:
+  enabled: false
+
+dns:
+  ndots: 2
+
+volumes:
+  enableLocalMount: false
+  nodeMountDirectory: /mnt/working-storage
+  podMountDirectory: /var/working-storage
+
+application:
+  replicaCount: 1
+  javaOptions: ""
+  webPort: "8080"
+  nodePort: "30680"


### PR DESCRIPTION
Add the kafka-health service for Octocat. This is a copy of the sink service with the names changed.