### PR TITLE
INFRA-1116: Add proficiency-report chart that uses spark-operator to submit

### DIFF
--- a/charts/proficiency-report/Chart.yaml
+++ b/charts/proficiency-report/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: "0.1.0"
+description: Spark application for data aggregation for proficiency report
+name: proficiency-report
+version: 1.0.0
+icon: https://s3-us-west-2.amazonaws.com/gitprime-email-images/gitprime-logo-icon.png

--- a/charts/proficiency-report/Chart.yaml
+++ b/charts/proficiency-report/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 appVersion: "0.1.0"
 description: Spark application for data aggregation for proficiency report
 name: proficiency-report
+home: https://github.com/Git-Prime/gp-pyspark
+maintainers:
+  - name: Wylie Hobbs
+    email: wylie-hobbs@pluralsight.com
 version: 1.0.0
 icon: https://s3-us-west-2.amazonaws.com/gitprime-email-images/gitprime-logo-icon.png

--- a/charts/proficiency-report/README.md
+++ b/charts/proficiency-report/README.md
@@ -1,0 +1,8 @@
+proficiency-report
+==============
+This is a standalone process for data-aggregation. The application code is [here](https://github.com/Git-Prime/gp-pyspark).
+
+### Configuration
+This application uses [spark-operator](https://github.com/helm/charts/tree/master/incubator/sparkoperator) to run Spark jobs in Kubernetes. If you want multiple jobs, it's best to call this chart multiple times either with helm install or with multiple HelmRelease files and set your values accordingly.
+
+For more information on how these jobs work, see the user guide [here](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/master/docs/user-guide.md)

--- a/charts/proficiency-report/ci/pre-test.sh
+++ b/charts/proficiency-report/ci/pre-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+DIRECTION="${1}"
+
+function up(){
+    helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
+    kubectl create namespace spark-operator
+    helm install spark-operator incubator/sparkoperator --namespace spark-operator --set sparkJobNamespace=default --set operatorVersion=v1beta2-1.1.0-2.4.5 --wait
+    exit 0
+}
+
+function down(){
+    kubectl delete namespace spark-operator
+    helm uninstall spark-operator -n spark-operator
+    exit 0
+}
+
+if [ "${DIRECTION}" == "up" ]; then
+    up
+elif [ "${DIRECTION}" == "down" ]; then
+    down
+else
+    echo "Unknown function ${DIRECTION}. Exiting."
+    exit 1
+fi
+

--- a/charts/proficiency-report/ci/test-values.yaml
+++ b/charts/proficiency-report/ci/test-values.yaml
@@ -1,0 +1,46 @@
+application:
+  name: "proficiency-report"
+  namespace: "gp-pyspark"
+  # Can be "scheduled" (ScheduledSparkApplication) or "adhoc" (SparkApplication)
+  # Leave blank and the chart will not create anything
+  type: "adhoc"
+  # Only used on "scheduled" application type
+  schedule: ""
+  file: "local:///opt/spark/examples/src/main/python/pi.py"
+  sparkVersion: "2.4.5"
+  # Arguments for your application file - optional
+  arguments: ""
+
+serviceAccount:
+  create: true
+  name: "proficiency-report"
+
+# These actually do all the work
+executor:
+  cores: "100m"
+  instances: 2
+  memory: "256Mi"
+  image:
+    repository: "gcr.io/spark/spark"
+    tag: "v2.4.5"
+    pullPolicy: "Always"
+  env: []
+  database:
+    password:
+      ref_master: "some-secret-key-ref"
+      ref_slave: "some-secret-key-ref"
+
+# Should not need to have more than one instance
+driver:
+  cores: "100m"
+  instances: 1
+  memory: "256Mi"
+  image:
+    repository: "gcr.io/spark/spark"
+    tag: "v2.4.5"
+    pullPolicy: "Always"
+  env: []
+  database:
+    password:
+      ref_master: "some-secret-key-ref"
+      ref_slave: "some-secret-key-ref"

--- a/charts/proficiency-report/ci/test-values.yaml
+++ b/charts/proficiency-report/ci/test-values.yaml
@@ -1,6 +1,6 @@
 application:
   name: "proficiency-report"
-  namespace: "gp-pyspark"
+  namespace: "default"
   # Can be "scheduled" (ScheduledSparkApplication) or "adhoc" (SparkApplication)
   # Leave blank and the chart will not create anything
   type: "adhoc"
@@ -17,11 +17,11 @@ serviceAccount:
 
 # These actually do all the work
 executor:
-  cores: "100m"
+  cores: 1
   instances: 2
-  memory: "256Mi"
+  memory: "512m"
   image:
-    repository: "gcr.io/spark/spark"
+    repository: "gcr.io/spark-operator/spark-py"
     tag: "v2.4.5"
     pullPolicy: "Always"
   env: []
@@ -32,11 +32,11 @@ executor:
 
 # Should not need to have more than one instance
 driver:
-  cores: "100m"
+  cores: 1
   instances: 1
-  memory: "256Mi"
+  memory: "512m"
   image:
-    repository: "gcr.io/spark/spark"
+    repository: "gcr.io/spark-operator/spark-py"
     tag: "v2.4.5"
     pullPolicy: "Always"
   env: []

--- a/charts/proficiency-report/templates/NOTES.txt
+++ b/charts/proficiency-report/templates/NOTES.txt
@@ -1,0 +1,8 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}

--- a/charts/proficiency-report/templates/_helpers.tpl
+++ b/charts/proficiency-report/templates/_helpers.tpl
@@ -16,6 +16,10 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "proficiency-report.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/proficiency-report/templates/_helpers.tpl
+++ b/charts/proficiency-report/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "proficiency-report.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "proficiency-report.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "proficiency-report.labels" -}}
+helm.sh/chart: {{ include "proficiency-report.chart" . }}
+{{ include "proficiency-report.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "proficiency-report.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "proficiency-report.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "proficiency-report.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "proficiency-report.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/proficiency-report/templates/scheduledsparkapplication.yaml
+++ b/charts/proficiency-report/templates/scheduledsparkapplication.yaml
@@ -26,7 +26,7 @@ spec:
     driver:
       cores: {{ .Values.driver.cores }}
       instances: {{ .Values.driver.instances }}
-      memory: {{ .Values.driver.memory }}
+      memory: "{{ .Values.driver.memory }}"
       serviceAccount: {{ .Values.serviceAccount.name }}
       image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
       imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
@@ -50,7 +50,7 @@ spec:
     executor:
       cores: {{ .Values.executor.cores }}
       instances: {{ .Values.executor.instances }}
-      memory: {{ .Values.executor.memory }}
+      memory: "{{ .Values.executor.memory }}"
       serviceAccount: {{ .Values.serviceAccount.name }}
       image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
       imagePullPolicy: {{ .Values.executor.image.pullPolicy }}

--- a/charts/proficiency-report/templates/scheduledsparkapplication.yaml
+++ b/charts/proficiency-report/templates/scheduledsparkapplication.yaml
@@ -1,18 +1,18 @@
-{{- if eq .Values.applicationType "scheduled" }}
+{{- if eq .Values.application.type "scheduled" }}
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: ScheduledSparkApplication
 metadata:
-  name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
+  name: {{ .Values.application.name }}
+  namespace: {{ .Values.application.namespace }}
 spec:
-  schedule: "{{ .Values.schedule }}"
+  schedule: "{{ .Values.application.schedule }}"
   type: Python
   pythonVersion: "3"
   mode: cluster
-  mainApplicationFile: {{ .Values.main.applicationFile }}
-  sparkVersion: {{ .Values.main.sparkVersion }}
+  mainApplicationFile: {{ .Values.application.file }}
+  sparkVersion: {{ .Values.application.sparkVersion }}
   arguments:
-    - '{{ .Values.main.arguments }}'
+    - '{{ .Values.application.arguments }}'
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3

--- a/charts/proficiency-report/templates/scheduledsparkapplication.yaml
+++ b/charts/proficiency-report/templates/scheduledsparkapplication.yaml
@@ -1,0 +1,70 @@
+{{- if eq .Values.applicationType "scheduled" }}
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: ScheduledSparkApplication
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  schedule: "{{ .Values.schedule }}"
+  type: Python
+  pythonVersion: "3"
+  mode: cluster
+  mainApplicationFile: {{ .Values.main.applicationFile }}
+  sparkVersion: {{ .Values.main.sparkVersion }}
+  arguments:
+    - '{{ .Values.main.arguments }}'
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  driver:
+    cores: {{ .Values.driver.cores }}
+    instances: {{ .Values.driver.instances }}
+    memory: {{ .Values.driver.memory }}
+    serviceAccount: {{ .Values.serviceAccount.name }}
+    image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
+    imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
+    labels:
+      version: 2.4.5
+    env:
+    {{- range $key, $value := .Values.driver.env }}
+    - name: {{ $key | quote }}
+      value: {{ $value | quote }}
+    {{- end }}
+    - name: DATABASE_PASSWORD_MASTER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.driver.database.password.ref_master }}
+          key: password
+    - name: DATABASE_PASSWORD_SLAVE
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.driver.database.password.ref_slave }}
+          key: password
+  executor:
+    cores: {{ .Values.executor.cores }}
+    instances: {{ .Values.executor.instances }}
+    memory: {{ .Values.executor.memory }}
+    serviceAccount: {{ .Values.serviceAccount.name }}
+    image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
+    imagePullPolicy: {{ .Values.executor.image.pullPolicy }}
+    labels:
+      version: 2.4.5
+    env:
+    {{- range $key, $value := .Values.executor.env }}
+    - name: {{ $key | quote }}
+      value: {{ $value | quote }}
+    {{- end }}
+    - name: DATABASE_PASSWORD_MASTER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.executor.database.password.ref_master }}
+          key: password
+    - name: DATABASE_PASSWORD_SLAVE
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.executor.database.password.ref_slave }}
+          key: password
+{{- end }}

--- a/charts/proficiency-report/templates/scheduledsparkapplication.yaml
+++ b/charts/proficiency-report/templates/scheduledsparkapplication.yaml
@@ -6,65 +6,71 @@ metadata:
   namespace: {{ .Values.application.namespace }}
 spec:
   schedule: "{{ .Values.application.schedule }}"
-  type: Python
-  pythonVersion: "3"
-  mode: cluster
-  mainApplicationFile: {{ .Values.application.file }}
-  sparkVersion: {{ .Values.application.sparkVersion }}
-  arguments:
-    - '{{ .Values.application.arguments }}'
-  restartPolicy:
-    type: OnFailure
-    onFailureRetries: 3
-    onFailureRetryInterval: 10
-    onSubmissionFailureRetries: 5
-    onSubmissionFailureRetryInterval: 20
-  driver:
-    cores: {{ .Values.driver.cores }}
-    instances: {{ .Values.driver.instances }}
-    memory: {{ .Values.driver.memory }}
-    serviceAccount: {{ .Values.serviceAccount.name }}
-    image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
-    imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
-    labels:
-      version: 2.4.5
-    env:
-    {{- range $key, $value := .Values.driver.env }}
-    - name: {{ $key | quote }}
-      value: {{ $value | quote }}
-    {{- end }}
-    - name: DATABASE_PASSWORD_MASTER
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.driver.database.password.ref_master }}
-          key: password
-    - name: DATABASE_PASSWORD_SLAVE
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.driver.database.password.ref_slave }}
-          key: password
-  executor:
-    cores: {{ .Values.executor.cores }}
-    instances: {{ .Values.executor.instances }}
-    memory: {{ .Values.executor.memory }}
-    serviceAccount: {{ .Values.serviceAccount.name }}
-    image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
-    imagePullPolicy: {{ .Values.executor.image.pullPolicy }}
-    labels:
-      version: 2.4.5
-    env:
-    {{- range $key, $value := .Values.executor.env }}
-    - name: {{ $key | quote }}
-      value: {{ $value | quote }}
-    {{- end }}
-    - name: DATABASE_PASSWORD_MASTER
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.executor.database.password.ref_master }}
-          key: password
-    - name: DATABASE_PASSWORD_SLAVE
-      valueFrom:
-        secretKeyRef:
-          name: {{ .Values.executor.database.password.ref_slave }}
-          key: password
+  concurrencyPolicy: Forbid
+  successfulRunHistoryLimit: 2
+  failedRunHistoryLimit: 3
+  template:
+    type: Python
+    pythonVersion: "3"
+    mode: cluster
+    mainApplicationFile: {{ .Values.application.file }}
+    sparkVersion: {{ .Values.application.sparkVersion }}
+    arguments:
+      - '{{ .Values.application.arguments }}'
+    restartPolicy:
+      type: OnFailure
+      onFailureRetries: 3
+      onFailureRetryInterval: 10
+      onSubmissionFailureRetries: 5
+      onSubmissionFailureRetryInterval: 20
+    driver:
+      cores: {{ .Values.driver.cores }}
+      instances: {{ .Values.driver.instances }}
+      memory: {{ .Values.driver.memory }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+      image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
+      imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
+      labels:
+        version: 2.4.5
+      env:
+      {{- range $key, $value := .Values.driver.env }}
+      - name: {{ $key | quote }}
+        value: {{ $value | quote }}
+      {{- end }}
+      - name: DATABASE_PASSWORD_MASTER
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.driver.database.password.ref_master }}
+            key: password
+      - name: DATABASE_PASSWORD_SLAVE
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.driver.database.password.ref_slave }}
+            key: password
+    executor:
+      cores: {{ .Values.executor.cores }}
+      instances: {{ .Values.executor.instances }}
+      memory: {{ .Values.executor.memory }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+      image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
+      imagePullPolicy: {{ .Values.executor.image.pullPolicy }}
+      labels:
+        version: 2.4.5
+      env:
+      {{- range $key, $value := .Values.executor.env }}
+      - name: {{ $key | quote }}
+        value: {{ $value | quote }}
+      {{- end }}
+      - name: DATABASE_PASSWORD_MASTER
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.executor.database.password.ref_master }}
+            key: password
+      - name: DATABASE_PASSWORD_SLAVE
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Values.executor.database.password.ref_slave }}
+            key: password
+    restartPolicy:
+      type: Never
 {{- end }}

--- a/charts/proficiency-report/templates/serviceaccount.yaml
+++ b/charts/proficiency-report/templates/serviceaccount.yaml
@@ -3,13 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "proficiency-report.serviceAccountName" . }}
+  namespace: {{ .Values.application.namespace }}
   labels:
 {{ include "proficiency-report.labels" . | nindent 4 }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: proficiency-report
+  namespace: {{ .Values.application.namespace }}
   name: spark-controller-submit
 rules:
 - apiGroups: ["", "extensions", "apps"]
@@ -20,7 +21,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: spark-controller-submit-binding
-  namespace: proficiency-report
+  namespace: {{ .Values.application.namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "proficiency-report.serviceAccountName" . }}

--- a/charts/proficiency-report/templates/serviceaccount.yaml
+++ b/charts/proficiency-report/templates/serviceaccount.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "proficiency-report.serviceAccountName" . }}
+  labels:
+{{ include "proficiency-report.labels" . | nindent 4 }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: proficiency-report
+  name: spark-controller-submit
+rules:
+- apiGroups: ["", "extensions", "apps"]
+  resources: ["deployments", "replicasets", "pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: spark-controller-submit-binding
+  namespace: proficiency-report
+subjects:
+- kind: ServiceAccount
+  name: {{ include "proficiency-report.serviceAccountName" . }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: spark-controller-submit
+  apiGroup: ""
+{{- end }}

--- a/charts/proficiency-report/templates/sparkapplication.yaml
+++ b/charts/proficiency-report/templates/sparkapplication.yaml
@@ -1,0 +1,69 @@
+{{- if eq .Values.applicationType "adhoc" }}
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  type: Python
+  pythonVersion: "3"
+  mode: cluster
+  mainApplicationFile: {{ .Values.main.applicationFile }}
+  sparkVersion: {{ .Values.main.sparkVersion }}
+  arguments:
+    - '{{ .Values.main.arguments }}'
+  restartPolicy:
+    type: OnFailure
+    onFailureRetries: 3
+    onFailureRetryInterval: 10
+    onSubmissionFailureRetries: 5
+    onSubmissionFailureRetryInterval: 20
+  driver:
+    cores: {{ .Values.driver.cores }}
+    instances: {{ .Values.driver.instances }}
+    memory: {{ .Values.driver.memory }}
+    serviceAccount: {{ .Values.serviceAccount.name }}
+    image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
+    imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
+    labels:
+      version: 2.4.5
+    env:
+    {{- range $key, $value := .Values.driver.env }}
+    - name: {{ $key | quote }}
+      value: {{ $value | quote }}
+    {{- end }}
+    - name: DATABASE_PASSWORD_MASTER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.driver.database.password.ref_master }}
+          key: password
+    - name: DATABASE_PASSWORD_SLAVE
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.driver.database.password.ref_slave }}
+          key: password
+  executor:
+    cores: {{ .Values.executor.cores }}
+    instances: {{ .Values.executor.instances }}
+    memory: {{ .Values.executor.memory }}
+    serviceAccount: {{ .Values.serviceAccount.name }}
+    image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
+    imagePullPolicy: {{ .Values.executor.image.pullPolicy }}
+    labels:
+      version: 2.4.5
+    env:
+    {{- range $key, $value := .Values.executor.env }}
+    - name: {{ $key | quote }}
+      value: {{ $value | quote }}
+    {{- end }}
+    - name: DATABASE_PASSWORD_MASTER
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.executor.database.password.ref_master }}
+          key: password
+    - name: DATABASE_PASSWORD_SLAVE
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.executor.database.password.ref_slave }}
+          key: password
+{{- end }}

--- a/charts/proficiency-report/templates/sparkapplication.yaml
+++ b/charts/proficiency-report/templates/sparkapplication.yaml
@@ -1,17 +1,17 @@
-{{- if eq .Values.applicationType "adhoc" }}
+{{- if eq .Values.application.type "adhoc" }}
 apiVersion: "sparkoperator.k8s.io/v1beta2"
 kind: SparkApplication
 metadata:
-  name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
+  name: {{ .Values.application.name }}
+  namespace: {{ .Values.application.namespace }}
 spec:
   type: Python
   pythonVersion: "3"
   mode: cluster
-  mainApplicationFile: {{ .Values.main.applicationFile }}
-  sparkVersion: {{ .Values.main.sparkVersion }}
+  mainApplicationFile: {{ .Values.application.file }}
+  sparkVersion: {{ .Values.application.sparkVersion }}
   arguments:
-    - '{{ .Values.main.arguments }}'
+    - '{{ .Values.application.arguments }}'
   restartPolicy:
     type: OnFailure
     onFailureRetries: 3

--- a/charts/proficiency-report/templates/sparkapplication.yaml
+++ b/charts/proficiency-report/templates/sparkapplication.yaml
@@ -21,7 +21,7 @@ spec:
   driver:
     cores: {{ .Values.driver.cores }}
     instances: {{ .Values.driver.instances }}
-    memory: {{ .Values.driver.memory }}
+    memory: {{ .Values.driver.memory | quote }}
     serviceAccount: {{ .Values.serviceAccount.name }}
     image: {{ .Values.driver.image.repository }}:{{ .Values.driver.image.tag }}
     imagePullPolicy: {{ .Values.driver.image.pullPolicy }}
@@ -45,7 +45,7 @@ spec:
   executor:
     cores: {{ .Values.executor.cores }}
     instances: {{ .Values.executor.instances }}
-    memory: {{ .Values.executor.memory }}
+    memory: {{ .Values.executor.memory | quote }}
     serviceAccount: {{ .Values.serviceAccount.name }}
     image: {{ .Values.executor.image.repository }}:{{ .Values.executor.image.tag }}
     imagePullPolicy: {{ .Values.executor.image.pullPolicy }}

--- a/charts/proficiency-report/templates/tests/test-configmap.yaml
+++ b/charts/proficiency-report/templates/tests/test-configmap.yaml
@@ -23,7 +23,7 @@ data:
         echo "*** appliation = ${application}"
         echo "*** executors = ${executors}"
         echo "*** driver active = ${driver_active}"
-        echo "*** executor logs = ${executor_active}"
+        echo "*** executor active = ${executor_active}"
 
         [[ ${driver_active} == true ]]
         [[ ${executor_active} == true ]]

--- a/charts/proficiency-report/templates/tests/test-configmap.yaml
+++ b/charts/proficiency-report/templates/tests/test-configmap.yaml
@@ -1,0 +1,31 @@
+  
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "proficiency-report.fullname" . }}-test
+  labels:
+    app: {{ include "proficiency-report.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+data:
+  run.sh: |-
+    @test "Test that SparkApplication completed successfully" {
+        url="http://proficiency-report-ui-svc.default:4040/api/v1/applications"
+        curlopts="--retry 60 --retry-delay 1 --retry-connrefused"
+        application=$(curl ${curlopts} ${url} | jq '.[].id' | tr -d '"')
+        sleep 10
+        executors=$(curl ${curlopts} ${url}/${application}/executors)
+        driver_logs=$(curl ${curlopts} ${url}/${application}/executors/driver/threads)
+        executor_logs=$(curl ${curlopts} ${url}/${application}/executors/1/threads)
+        driver_active=$(echo ${executors} | jq '.[0].isActive')
+        executor_active=$(echo ${executors} | jq '.[1].isActive')
+        echo "*** appliation = ${application}"
+        echo "*** executors = ${executors}"
+        echo "*** driver active = ${driver_active}"
+        echo "*** executor logs = ${executor_active}"
+
+        [[ ${driver_active} == true ]]
+        [[ ${executor_active} == true ]]
+
+    }

--- a/charts/proficiency-report/templates/tests/test-status.yaml
+++ b/charts/proficiency-report/templates/tests/test-status.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "proficiency-report.fullname" . }}-test-status"
+  labels:
+{{ include "proficiency-report.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "gp-docker.gitprime-ops.com/flow-ci/bats:latest"
+      args: [ "/tests/run.sh" ]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ include "proficiency-report.fullname" . }}-test
+  restartPolicy: Never

--- a/charts/proficiency-report/values.yaml
+++ b/charts/proficiency-report/values.yaml
@@ -1,0 +1,45 @@
+name: proficiency-report
+namespace: gp-pyspark
+
+# Can be "scheduled" (ScheduledSparkApplication) or "adhoc" (SparkApplication)
+# Leave blank and the chart will not create anything
+applicationType: ""
+
+serviceAccount:
+  create: true
+  name: "proficiency-report"
+
+# These actually do all the work
+executor:
+  cores: 1
+  instances: 1
+  memory: "512Mi"
+  image:
+    repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
+    tag: "latest"
+    pullPolicy: Always
+  env: []
+  database:
+    password:
+      ref_master: "some-secret-key-ref"
+      ref_slave: "some-secret-key-ref"
+
+# Should not need to have more than one instance
+driver:
+  cores: 1
+  instances: 1
+  memory: "1024Mi"
+  image:
+    repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
+    tag: "latest"
+    pullPolicy: Always
+  env: []
+  database:
+    password:
+      ref_master: "some-secret-key-ref"
+      ref_slave: "some-secret-key-ref"
+
+main:
+  applicationFile: "local://"
+  sparkVersion: "2.4.5"
+  arguments: "--your --script arguments"

--- a/charts/proficiency-report/values.yaml
+++ b/charts/proficiency-report/values.yaml
@@ -18,7 +18,7 @@ serviceAccount:
 executor:
   cores: 1
   instances: 1
-  memory: "512Mi"
+  memory: "512m"
   image:
     repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
     tag: "latest"
@@ -33,7 +33,7 @@ executor:
 driver:
   cores: 1
   instances: 1
-  memory: "1024Mi"
+  memory: "1024m"
   image:
     repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
     tag: "latest"

--- a/charts/proficiency-report/values.yaml
+++ b/charts/proficiency-report/values.yaml
@@ -1,9 +1,14 @@
-name: proficiency-report
-namespace: gp-pyspark
-
-# Can be "scheduled" (ScheduledSparkApplication) or "adhoc" (SparkApplication)
-# Leave blank and the chart will not create anything
-applicationType: ""
+application:
+  name: "proficiency-report"
+  namespace: "gp-pyspark"
+  # Can be "scheduled" (ScheduledSparkApplication) or "adhoc" (SparkApplication)
+  # Leave blank and the chart will not create anything
+  type: ""
+  # Only used on "scheduled" application type
+  schedule: ""
+  file: "local://"
+  sparkVersion: "2.4.5"
+  arguments: "--your --script arguments"
 
 serviceAccount:
   create: true
@@ -17,7 +22,7 @@ executor:
   image:
     repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
     tag: "latest"
-    pullPolicy: Always
+    pullPolicy: "Always"
   env: []
   database:
     password:
@@ -32,14 +37,9 @@ driver:
   image:
     repository: "gp-docker.gitprime-ops.com/cloud/proficiency-spark"
     tag: "latest"
-    pullPolicy: Always
+    pullPolicy: "Always"
   env: []
   database:
     password:
       ref_master: "some-secret-key-ref"
       ref_slave: "some-secret-key-ref"
-
-main:
-  applicationFile: "local://"
-  sparkVersion: "2.4.5"
-  arguments: "--your --script arguments"


### PR DESCRIPTION
This is the evolution of the `gp-pyspark` chart. It leaves behind standard k8s cronjobs in favor of using spark-operator and the CRDs that it offers (SparkApplication and ScheduledSparkApplication). Jobs can parallelize properly using spark-operator, distributing smaller chunks of work across the cluster, instead of one big job.

There is a test for this chart in `templates/test` using the Spark API to check if some test jobs become active. I could not find a great way to determine if they succeed because of limitations around `bats` it seems. 